### PR TITLE
Support no authorization

### DIFF
--- a/lib/remote_record/github/base.rb
+++ b/lib/remote_record/github/base.rb
@@ -7,7 +7,7 @@ module RemoteRecord
       private
 
       def client
-        Octokit::Client.new(access_token: authorization)
+        Octokit::Client.new({ access_token: authorization }.compact)
       end
     end
   end

--- a/lib/remote_record/github/version.rb
+++ b/lib/remote_record/github/version.rb
@@ -2,6 +2,6 @@
 
 module RemoteRecord
   module GitHub
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
If `authorization` is falsy, we'll pass nothing to the client.